### PR TITLE
add spaces in method calls

### DIFF
--- a/src/zadf/zcl_adf_service_keyvault.clas.abap
+++ b/src/zadf/zcl_adf_service_keyvault.clas.abap
@@ -175,9 +175,9 @@ METHOD get_key_from_kv.
       RAISE EXCEPTION lcx_http.
   ENDTRY.
 *Optional - To help developer understand the origin of call
-  rest_handler->set_callingmethod('GET_KEY_FROM_KV').
+  rest_handler->set_callingmethod( 'GET_KEY_FROM_KV' ).
 *Optional - To help developer understand the origin of call
-  rest_handler->set_callingprogram('ZCL_ADF_SERVICE_KEYVAULT').
+  rest_handler->set_callingprogram( 'ZCL_ADF_SERVICE_KEYVAULT' ).
   rest_handler->zif_rest_framework~set_uri( '?api-version=2016-10-01' ).
 ************************************************************************
   CONCATENATE 'Bearer' gv_token INTO lv_token SEPARATED BY space.

--- a/src/zrest/zcl_rest_utility_class.clas.abap
+++ b/src/zrest/zcl_rest_utility_class.clas.abap
@@ -770,7 +770,7 @@ CLASS ZCL_REST_UTILITY_CLASS IMPLEMENTATION.
     IF wa_paylod-payload IS NOT INITIAL.
       rest_handler->zif_rest_framework~set_binary_body( wa_paylod-payload ).
     ENDIF.
-    rest_handler->set_callingmethod('RETRY').
+    rest_handler->set_callingmethod( 'RETRY' ).
 *   Append the headers to the message
     CLEAR lv_string.
     CALL FUNCTION 'ECATT_CONV_XSTRING_TO_STRING'
@@ -1018,7 +1018,7 @@ CLASS ZCL_REST_UTILITY_CLASS IMPLEMENTATION.
         rest_handler->set_request_header( iv_name = wa_header-name  iv_value = wa_header-value  ).
       ENDIF.
     ENDLOOP.
-    rest_handler->set_callingprogram('ZCL_REST_UTILITY_CLASS').
+    rest_handler->set_callingprogram( 'ZCL_REST_UTILITY_CLASS' ).
     lv_string = wa_paylod-uri.
     rest_handler->set_uri( lv_string ).
 *   Retry
@@ -1527,7 +1527,7 @@ CLASS ZCL_REST_UTILITY_CLASS IMPLEMENTATION.
         lo_send_request->add_recipient( i_recipient = lo_recipient ).
 
 *//     ---------- send document ---------------------------------------
-        lo_send_request->set_send_immediately('X').
+        lo_send_request->set_send_immediately( 'X' ).
         CALL METHOD lo_send_request->send(
           EXPORTING
             i_with_error_screen = 'X'

--- a/src/zrest/zrest_call_demo.prog.abap
+++ b/src/zrest/zrest_call_demo.prog.abap
@@ -34,9 +34,9 @@ ENDTRY.
 *----------------------Build the query params +Set the Payload here----*
 ************************************************************************
 *Optional - To help developer understand the origin of call
-rest_handler->set_callingmethod('CALL DEMO').
+rest_handler->set_callingmethod( 'CALL DEMO' ).
 *Optional - To help developer understand the origin of call
-rest_handler->set_callingprogram('ZREST_CALL_DEMO').
+rest_handler->set_callingprogram( 'ZREST_CALL_DEMO' ).
 rest_handler->set_request_header( iv_name = 'header1' iv_value = 'value for header1' ).
 rest_handler->set_request_header( iv_name = 'header2' iv_value = 'value for header2' ).
 ************************************************************************


### PR DESCRIPTION
add spaces in method calls

align method calls to have spaces between "(" and parameters