### PR TITLE
Update serializer of zsdk s_tabu_dis to native ABABGIT serializer

### DIFF
--- a/src/zadf/zsdk                          s_tabu_dis.sucu.xml
+++ b/src/zadf/zsdk                          s_tabu_dis.sucu.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUCU"" serializer_version="1.0">
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUCU" serializer_version="1.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <TBRG_AUTH>

--- a/src/zadf/zsdk                          s_tabu_dis.sucu.xml
+++ b/src/zadf/zsdk                          s_tabu_dis.sucu.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUCU" serializer_version="1.0">
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUCU" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <TBRG_AUTH>

--- a/src/zadf/zsdk                          s_tabu_dis.sucu.xml
+++ b/src/zadf/zsdk                          s_tabu_dis.sucu.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<abapGit version="v1.0.0" serializer="ZCL_ABAPGIT_OBJECT_BY_SOBJ" serializer_version="1.0">
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUCU"" serializer_version="1.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <TBRG_AUTH>


### PR DESCRIPTION
Problem:
Following the [installation guide ](https://github.com/Microsoft/ABAP-SDK-for-Azure/blob/master/ABAP%20SDK%20for%20Azure%20-%20Github.pdf) fails with error:
Object type SUCU is not supported by this system
Import of object ZSDK S_TABU_DIS failed 

Situation:
ABAPGIT already support a native serializer for Object Type SUCU.
You already updated the serializer for object: [zres s_tabu_dis](https://github.com/microsoft/ABAP-SDK-for-Azure/blob/master/src/zrest/zres%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20s_tabu_dis.sucu.xml)
but for object [zsdk s_tabu_dis](https://github.com/microsoft/ABAP-SDK-for-Azure/blob/master/src/zadf/zsdk%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20s_tabu_dis.sucu.xml) you still use the serialisier which require a plugin.

Solution:
Update serializer in [zsdk s_tabu_dis](https://github.com/microsoft/ABAP-SDK-for-Azure/blob/master/src/zadf/zsdk%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20s_tabu_dis.sucu.xml)

Tested:
![image](https://user-images.githubusercontent.com/25051245/165257432-9f76ab93-5561-427c-8855-3986606f401d.png)
