### PR TITLE
Add User-Agent header to ADF service

### DIFF
--- a/src/zadf/zcl_adf_service.clas.abap
+++ b/src/zadf/zcl_adf_service.clas.abap
@@ -1115,6 +1115,9 @@ METHOD send.
 * Add Managed Identity/AAD/SAS keys to the headers
     add_request_header( iv_name = 'Authorization' iv_value = lv_sas_token ).
 
+* Add User Agent String keys to the headers
+    add_request_header( iv_name = 'User-Agent' iv_value = 'SAP-Azure-Telemetry-Client/1.0' ).
+
     go_rest_api->zif_rest_framework~set_binary_body( request ).
     IF NOT it_headers[] IS INITIAL.
       go_rest_api->zif_rest_framework~set_request_headers( it_header_fields = it_headers[] ).


### PR DESCRIPTION
Insert a User-Agent header ('SAP-Azure-Telemetry-Client/1.0') in zcl_adf_service->send. 
This change introduces an additional HTTP header in ZCL_ADF_SERVICE->SEND() to tag outgoing requests originating from the ABAP SDK for Azure.
The header is used solely for anonymous usage analytics, enabling us to understand which SDK features are exercised in real customer scenarios. The insights support data‑driven prioritization of enhancements, identification of feature gaps, and continuous improvement of SDK quality and developer experience.
The change is non‑functional: it does not alter runtime behavior and does not expose business data or payload content.