### PR TITLE
Update mainprogram conditions in access key management

### DIFF
--- a/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
+++ b/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
@@ -102,11 +102,11 @@ CLASS ZCL_ADF_MANAGE_ACCESS_KEYS IMPLEMENTATION.
 
     LOOP AT lt_abap_stack INTO ls_abap_stack
             WHERE mainprogram EQ 'SAPLZSSF_FG' OR
-                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP' OR     
+                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP' OR
                   mainprogram EQ 'ZCL_ADF_MANAGE_INTERFACE_KEY==CP' OR
                   mainprogram EQ 'ZADF_VALIDATE_AND_ADJUST_KEYS' OR
                   mainprogram EQ 'ZSSF_VALIDATE_AND_ADJUST_KEYS' OR
-                  mainprogram EQ 'ZCL_SSF_UTILITY===============CP'.     " AND blockname EQ 'DECODE_SIGN' ).  " <-- Too restrictive
+                  mainprogram EQ 'ZCL_SSF_UTILITY===============CP'.
       IF sy-subrc = 0.
         lv_allowed = abap_true.
       ENDIF.

--- a/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
+++ b/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
@@ -102,11 +102,11 @@ CLASS ZCL_ADF_MANAGE_ACCESS_KEYS IMPLEMENTATION.
 
     LOOP AT lt_abap_stack INTO ls_abap_stack
             WHERE mainprogram EQ 'SAPLZSSF_FG' OR
-                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP'      " <--- Missing mainprogram
+                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP' OR     
                   mainprogram EQ 'ZCL_ADF_MANAGE_INTERFACE_KEY==CP' OR
                   mainprogram EQ 'ZADF_VALIDATE_AND_ADJUST_KEYS' OR
                   mainprogram EQ 'ZSSF_VALIDATE_AND_ADJUST_KEYS' OR
-                ( mainprogram EQ 'ZCL_SSF_UTILITY===============CP'.     " AND blockname EQ 'DECODE_SIGN' ).  " <-- Too restrictive
+                  mainprogram EQ 'ZCL_SSF_UTILITY===============CP'.     " AND blockname EQ 'DECODE_SIGN' ).  " <-- Too restrictive
       IF sy-subrc = 0.
         lv_allowed = abap_true.
       ENDIF.

--- a/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
+++ b/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
@@ -102,10 +102,11 @@ CLASS ZCL_ADF_MANAGE_ACCESS_KEYS IMPLEMENTATION.
 
     LOOP AT lt_abap_stack INTO ls_abap_stack
             WHERE mainprogram EQ 'SAPLZSSF_FG' OR
+                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP'      " <--- Missing mainprogram 
                   mainprogram EQ 'ZCL_ADF_MANAGE_INTERFACE_KEY==CP' OR
                   mainprogram EQ 'ZADF_VALIDATE_AND_ADJUST_KEYS' OR
                   mainprogram EQ 'ZSSF_VALIDATE_AND_ADJUST_KEYS' OR
-                ( mainprogram EQ 'ZCL_SSF_UTILITY===============CP' AND blockname EQ 'DECODE_SIGN' ).
+                ( mainprogram EQ 'ZCL_SSF_UTILITY===============CP'.     " AND blockname EQ 'DECODE_SIGN' ).  " <-- Too restrictive
       IF sy-subrc = 0.
         lv_allowed = abap_true.
       ENDIF.

--- a/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
+++ b/src/zadf/zadf_sec/zcl_adf_manage_access_keys.clas.abap
@@ -102,7 +102,7 @@ CLASS ZCL_ADF_MANAGE_ACCESS_KEYS IMPLEMENTATION.
 
     LOOP AT lt_abap_stack INTO ls_abap_stack
             WHERE mainprogram EQ 'SAPLZSSF_FG' OR
-                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP'      " <--- Missing mainprogram 
+                  mainprogram eq 'ZCL_ADF_MANAGE_ACCESS_KEYS====CP'      " <--- Missing mainprogram
                   mainprogram EQ 'ZCL_ADF_MANAGE_INTERFACE_KEY==CP' OR
                   mainprogram EQ 'ZADF_VALIDATE_AND_ADJUST_KEYS' OR
                   mainprogram EQ 'ZSSF_VALIDATE_AND_ADJUST_KEYS' OR


### PR DESCRIPTION
Adjusted mainprogram conditions in the loop to include a missing case and made the condition less restrictive.

See: https://github.com/microsoft/ABAP-SDK-for-Azure/issues/171#issuecomment-4925170111