### PR TITLE
enable rule parser_error configuration in abaplint.json

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -203,7 +203,10 @@
       "requested": true,
       "setExtended": true
     },
-    "parser_error": false,
+    "parser_error": {
+      "exclude": ["svim.xml"],
+      "severity": "Error"
+    },
     "remove_descriptions": false,
     "sequential_blank": false,
     "short_case": {


### PR DESCRIPTION
then the errors will show up in eg. https://github.com/microsoft/ABAP-SDK-for-Azure/pull/173 when the ABAP is not valid